### PR TITLE
fix: Fix markdown table syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ It also outputs structured logs to standard out.
 Prodzilla tracks the following metrics:
 
 | Name | Type | Description |
-| ---- | ---- | ----------- ||
+| ---- | ---- | ----------- |
 | runs     | Counter(u64)   | The total number of executions for this test |
 | duration | Histogram(u64) | Time taken to execute the test               |
 | errors   | Counter(u64)   | The total number of errors for this test     |


### PR DESCRIPTION
Seems like I accidentally broke a table in the README by adding a pipe too many!