### PR TITLE
chore: Bump version to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "prodzilla"
-version = "0.0.3-rc.5"
+version = "0.0.3"
 dependencies = [
  "axum 0.7.5",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "prodzilla"
-version = "0.0.3-rc.5"
+version = "0.0.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Now that the changes have been merged it might be a good time to properly release v0.0.3 -- the process for this in Github Actions is to push a tag `v0.0.3`, which will trigger creation of a GitHub Release as well as the build of a Docker image.

This should be done from `main` after merging an update to the version number in Cargo, which is what this PR does.

So basically the steps for a release become:

1. Bump version number in `Cargo.toml` (and `Cargo.lock` by building)
2. Commit and push version increment
3. `git tag v0.0.3`
4. `git push --tags`

The PR description for #16 can probably be used as a changelog, feel free to rewrite it as you see fit (I could also help with this if you'd prefer) 😄 