### PR TITLE
feat: Add Prometheus support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-prometheus"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1a24eafe47b693cb938f8505f240dc26c71db60df9aca376b4f857e9653ec7"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,9 +1405,11 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
  "opentelemetry_sdk",
+ "prometheus",
  "regex",
  "reqwest",
  "serde",
@@ -1405,6 +1420,21 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
 ]
 
 [[package]]
@@ -1429,6 +1459,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,5 @@ opentelemetry-otlp = { version = "0.16.0", features = [
 opentelemetry-semantic-conventions = "0.15.0"
 clap = { version = "4.5.4", features = ["derive"] }
 opentelemetry-stdout = { version = "0.4.0", features = ["metrics", "trace"] }
+opentelemetry-prometheus = "0.16.0"
+prometheus = "0.13.4"

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Progress on the base set of synthetic monitoring features is loosely tracked bel
     - In a Database
 - Output
     - JSON output of results for all probes :white_check_mark:
-    - Prometheus Endpoint
+    - Prometheus Endpoint :white_check_mark:
     - UI output of results for all probes
 - Forwarding alerts
     - Webhooks :white_check_mark:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To be part of the community, or for any questions, join our [Discord](https://di
     - [Tracked metrics](#tracked-metrics)
     - [Traces](#traces)
     - [Configuring OpenTelemetry export](#configuring-opentelemetry-export)
+      - [Prometheus](#prometheus)
     - [Configuring log level](#configuring-log-level)
 - [Deploying on Shuttle for Free](#deploying-on-shuttle-for-free)
 - [Feature Roadmap](#feature-roadmap)
@@ -309,10 +310,19 @@ Configuration follows the OpenTelemetry standard environment variables:
 - `OTEL_EXPORTER_OTLP_ENDPOINT` is used to define the collector endpoint. Defaults to `http://localhost:431`
 - `OTEL_EXPORTER_OTLP_PROTOCOL` is used to define the protocol that is used in export. Supported values are `http/protobuf`, `http/json` and `grpc`. Defaults to `grpc`.
 - `OTEL_EXPORTER_OTLP_TIMEOUT` is used to set an exporter timeout in seconds. Defaults to 10 seconds.
-- `OTEL_METRICS_EXPORTER` is used to define how metrics are exported. Supported values are `otlp` and `stdout`. If unset, metrics will not be exported.
+- `OTEL_METRICS_EXPORTER` is used to define how metrics are exported. Supported values are `otlp`, `stdout` and `prometheus`. If unset, metrics will not be exported.
 - `OTEL_TRACES_EXPORTER` is used to define how traces are exported. Supported values are `otlp` and `stdout`. If unset, traces will not exported.
 
 Furthermore, resource attributes can be set with `OTEL_RESOURCE_ATTRIBUTES`.
+
+#### Prometheus
+Prodzilla is also able to export the same metrics as a Prometheus endpoint. This is configured with the environment variables:
+
+- `OTEL_METRICS_EXPORTER` must be set to `prometheus`
+- `OTEL_EXPORTER_PROMETHEUS_HOST` is used to set the host to listen to. Defaults to `localhost`.
+- `OTEL_EXPORTER_PROMETHEUS_PORT` is used to set the port to listen to. Defaults to `9464`.
+
+Metrics are served at `/metrics` in the plain-text Prometheus format.
 
 ### Configuring log level
 The logging level can be set using the environment variable `RUST_LOG`. Supported levels are `trace`, `debug`, `info`, `warn`, and `error` in ascending order of severity.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use probe::schedule::schedule_probes;
 use probe::schedule::schedule_stories;
 use std::sync::Arc;
 use web_server::start_axum_server;
+use web_server::start_promtehus_server;
 
 use crate::{app_state::AppState, config::load_config};
 
@@ -27,7 +28,10 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    let _guard = otel::init();
+    let otel_state = otel::init();
+    if let Some(registry) = &otel_state.metrics.registry {
+        tokio::spawn(start_promtehus_server(registry.clone()));
+    }
 
     let config = load_config(args.file).await?;
 

--- a/src/otel/metrics.rs
+++ b/src/otel/metrics.rs
@@ -5,20 +5,36 @@ use opentelemetry::{
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     metrics::{
-        reader::{DefaultAggregationSelector, DefaultTemporalitySelector},
+        reader::{DefaultAggregationSelector, DefaultTemporalitySelector, MetricReader},
         MeterProviderBuilder, PeriodicReader, SdkMeterProvider,
     },
     runtime,
 };
-use std::env;
+
+use std::{env, sync::Arc};
 use tracing::debug;
 
 use crate::otel::create_otlp_export_config;
 
 use super::resource;
 
-pub fn create_meter_provider() -> Option<SdkMeterProvider> {
-    let reader = match env::var("OTEL_METRICS_EXPORTER") {
+fn build_meter_provider<T>(reader: T) -> SdkMeterProvider
+where
+    T: MetricReader,
+{
+    MeterProviderBuilder::default()
+        .with_resource(resource())
+        .with_reader(reader)
+        .build()
+}
+
+pub struct MetricsState {
+    pub meter: Option<SdkMeterProvider>,
+    pub registry: Option<Arc<prometheus::Registry>>,
+}
+
+pub fn initialize() -> MetricsState {
+    let (meter_provider, prometheus_registry) = match env::var("OTEL_METRICS_EXPORTER") {
         Ok(exporter_type) if exporter_type == "otlp" => {
             debug!("Using OTLP metrics exporter");
             let export_config = create_otlp_export_config();
@@ -52,26 +68,39 @@ pub fn create_meter_provider() -> Option<SdkMeterProvider> {
                     }
                 }
             };
-            PeriodicReader::builder(exporter, runtime::Tokio).build()
+            let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
+            (build_meter_provider(reader), None)
         }
         Ok(exporter_type) if exporter_type == "stdout" => {
             debug!("Using stdout metrics exporter");
             let exporter = opentelemetry_stdout::MetricsExporter::default();
-            PeriodicReader::builder(exporter, runtime::Tokio).build()
+            let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
+            (build_meter_provider(reader), None)
+        }
+        Ok(exporter_type) if exporter_type == "prometheus" => {
+            debug!("Using Prometheus metrics exporter");
+            let registry = prometheus::Registry::new();
+            let reader = opentelemetry_prometheus::exporter()
+                .with_registry(registry.clone())
+                .build()
+                .unwrap();
+            (build_meter_provider(reader), Some(Arc::new(registry)))
         }
         _ => {
             debug!("No metrics exporter configured");
-            return None;
+            return MetricsState {
+                meter: None,
+                registry: None,
+            };
         }
     };
-    let meter_provider = MeterProviderBuilder::default()
-        .with_resource(resource())
-        .with_reader(reader)
-        .build();
 
     global::set_meter_provider(meter_provider.clone());
 
-    Some(meter_provider)
+    MetricsState {
+        meter: Some(meter_provider),
+        registry: prometheus_registry,
+    }
 }
 
 pub struct Metrics {

--- a/src/web_server/prometheus_metrics.rs
+++ b/src/web_server/prometheus_metrics.rs
@@ -1,0 +1,25 @@
+use axum::{http::StatusCode, response::IntoResponse, Extension};
+
+use prometheus::Encoder;
+use std::sync::Arc;
+use tracing::error;
+
+pub async fn metrics_handler(
+    Extension(registry): Extension<Arc<prometheus::Registry>>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let encoder = prometheus::TextEncoder::new();
+    let metric_families = registry.gather();
+    let mut result = Vec::new();
+    if let Err(err) = encoder.encode(&metric_families, &mut result) {
+        error!("Failed to encode Prometheus metrics: {}", err);
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    };
+    let response = match String::from_utf8(result) {
+        Ok(response) => response,
+        Err(err) => {
+            error!("Failed to convert Prometheus metrics to string: {}", err);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    };
+    Ok((StatusCode::OK, response))
+}


### PR DESCRIPTION
Turns out it was pretty simple to add a Prometheus endpoint! I'm not entirely sure that I like the placement of the Prometheus handler in `web_server`, but I'm also not sure that I know where I would rather place it. It feels wrong to have it in the `otel` module since it does async, but it also feels a bit wrong to have it in `web_server` since it's a peripheral server. Let me know if you have any thoughts regarding this.


Resolves #4 .